### PR TITLE
md 以下ではカートアイコンのみを表示するように実装

### DIFF
--- a/app/Http/Controllers/CartController.php
+++ b/app/Http/Controllers/CartController.php
@@ -58,4 +58,15 @@ class CartController extends Controller
 
         return 'deleted.';
     }
+
+    public function indexForSidemenu(): View
+    {
+        $data = session()->exists($this->key)
+            ? session()->get($this->key, [])
+            : [];
+
+        return view('components.sidemenu-cart', [
+            'items' => $data,
+        ]);
+    }
 }

--- a/resources/views/cart.blade.php
+++ b/resources/views/cart.blade.php
@@ -2,7 +2,7 @@
 <div
     hx-target="closest .cart-item"
     hx-swap="outerHTML swap:0.5s"
-    class="bg-slate-100 dark:bg-slate-800 p-3"
+    class="w-auto hidden md:block bg-slate-100 dark:bg-slate-800 p-3"
     >
     <div>カート</div>
 
@@ -24,3 +24,5 @@
         </div>
     @endforeach
 </div>
+
+@include('components/cart')

--- a/resources/views/cart.blade.php
+++ b/resources/views/cart.blade.php
@@ -1,28 +1,15 @@
-{{-- delete 実行時にもっとも近い .cart-item を置き換えて削除する --}}
-<div
-    hx-target="closest .cart-item"
-    hx-swap="outerHTML swap:0.5s"
-    class="w-auto hidden md:block bg-slate-100 dark:bg-slate-800 p-3"
-    >
-    <div>カート</div>
+@extends('layouts.base')
 
-    @foreach ($items as $item)
-        <div class="w-auto rounded-xl m-3 p-3 border-2 border-sky-500 cart-item">
-            <div>商品名：{{ $item[0]['name'] }}</div>
-            <div>金額：{{ $item[0]['price'] }}</div>
-            <div>count：{{ $item[0]['count'] }}</div>
-            <div>total：{{ $item[0]['price'] * $item[0]['count'] }}</div>
-            <form>
-                @csrf
-                <button
-                    hx-delete="/cart?item_id={{$item[0]['id']}}"
-                    class="bg-gray-600 hover:bg-gray-500 text-white p-2 mt-2 rounded-lg"
-                    >
-                    delete
-                </button>
-            </form>
-        </div>
-    @endforeach
-</div>
+@section('title', 'cart')
 
-@include('components/cart')
+@section('main')
+    <div
+        hx-target="closest .cart-item"
+        hx-swap="outerHTML swap:0.5s"
+        class="w-auto bg-slate-100 dark:bg-slate-800 p-3"
+        >
+        <div>カート</div>
+
+        @include('components/cart-items')
+    </div>
+@endsection

--- a/resources/views/components/cart-items.blade.php
+++ b/resources/views/components/cart-items.blade.php
@@ -1,0 +1,18 @@
+@foreach ($items as $item)
+    <div class="w-auto rounded-xl m-3 p-3 border-2 border-sky-500 cart-item">
+        <div>商品名：{{ $item[0]['name'] }}</div>
+        <div>金額：{{ $item[0]['price'] }}</div>
+        <div>count：{{ $item[0]['count'] }}</div>
+        <div>total：{{ $item[0]['price'] * $item[0]['count'] }}</div>
+        <form>
+            @csrf
+            <button
+                hx-delete="/cart?item_id={{$item[0]['id']}}"
+                class="bg-gray-600 hover:bg-gray-500 text-white p-2 mt-2 rounded-lg"
+                >
+                delete
+            </button>
+        </form>
+    </div>
+@endforeach
+

--- a/resources/views/components/cart.blade.php
+++ b/resources/views/components/cart.blade.php
@@ -1,4 +1,6 @@
-<div class="md:hidden fixed bottom-6 right-5 bg-blue-500 rounded-full p-3">
+<a
+    href="/cart"
+    class="md:hidden fixed bottom-6 right-5 bg-blue-500 rounded-full p-3">
     <div>
         <div class="text-white absolute -top-1 -right-1 font-bold">
             {{ count($items) }}
@@ -12,5 +14,4 @@
                 d="M2.25 2.25a.75.75 0 0 0 0 1.5h1.386c.17 0 .318.114.362.278l2.558 9.592a3.752 3.752 0 0 0-2.806 3.63c0 .414.336.75.75.75h15.75a.75.75 0 0 0 0-1.5H5.378A2.25 2.25 0 0 1 7.5 15h11.218a.75.75 0 0 0 .674-.421 60.358 60.358 0 0 0 2.96-7.228.75.75 0 0 0-.525-.965A60.864 60.864 0 0 0 5.68 4.509l-.232-.867A1.875 1.875 0 0 0 3.636 2.25H2.25ZM3.75 20.25a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0ZM16.5 20.25a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0Z" />
         </svg>
     </div>
-</div>
-
+</a>

--- a/resources/views/components/cart.blade.php
+++ b/resources/views/components/cart.blade.php
@@ -1,0 +1,16 @@
+<div class="md:hidden fixed bottom-6 right-5 bg-blue-500 rounded-full p-3">
+    <div>
+        <div class="text-white absolute -top-1 -right-1 font-bold">
+            {{ count($items) }}
+        </div>
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            class="w-6 h-6 fill-white">
+            <path
+                d="M2.25 2.25a.75.75 0 0 0 0 1.5h1.386c.17 0 .318.114.362.278l2.558 9.592a3.752 3.752 0 0 0-2.806 3.63c0 .414.336.75.75.75h15.75a.75.75 0 0 0 0-1.5H5.378A2.25 2.25 0 0 1 7.5 15h11.218a.75.75 0 0 0 .674-.421 60.358 60.358 0 0 0 2.96-7.228.75.75 0 0 0-.525-.965A60.864 60.864 0 0 0 5.68 4.509l-.232-.867A1.875 1.875 0 0 0 3.636 2.25H2.25ZM3.75 20.25a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0ZM16.5 20.25a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0Z" />
+        </svg>
+    </div>
+</div>
+

--- a/resources/views/components/sidemenu-cart.blade.php
+++ b/resources/views/components/sidemenu-cart.blade.php
@@ -1,0 +1,12 @@
+{{-- delete 実行時にもっとも近い .cart-item を置き換えて削除する --}}
+<div
+    hx-target="closest .cart-item"
+    hx-swap="outerHTML swap:0.5s"
+    class="w-auto hidden md:block bg-slate-100 dark:bg-slate-800 p-3"
+    >
+    <div>カート</div>
+
+    @include('components/cart-items')
+</div>
+
+@include('components/cart')

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -5,13 +5,6 @@
 @section('main')
     <div class="md:flex">
         <div
-            id="cart"
-            hx-get="/cart"
-            hx-trigger="load"
-            class="w-auto md:hidden"
-            >
-        </div>
-        <div
             class="w-auto md:w-3/4"
             hx-get="/items"
             hx-trigger="load"
@@ -21,7 +14,7 @@
             id="cart"
             hx-get="/cart"
             hx-trigger="load"
-            class="hidden md:block md:w-1/4"
+            class="w-auto hidden md:block"
             >
         </div>
     </div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -12,7 +12,7 @@
         </div>
         <div
             id="cart"
-            hx-get="/cart"
+            hx-get="/cart/sidemenu"
             hx-trigger="load"
             >
         </div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -14,7 +14,6 @@
             id="cart"
             hx-get="/cart"
             hx-trigger="load"
-            class="w-auto hidden md:block"
             >
         </div>
     </div>

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -23,7 +23,7 @@
                 <div class="relative w-full max-w-2xl px-6 lg:max-w-7xl">
                     @include('partials.header')
 
-                    <main class="mt-6">
+                    <main class="mt-6 relative">
                         @yield('main')
                     </main>
 

--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -1,31 +1,5 @@
-<div class="grid grid-cols-2 items-center gap-2 py-10 lg:grid-cols-3">
-    header
-    @if (Route::has('login'))
-        <nav class="-mx-3 flex flex-1 justify-end">
-            @auth
-                <a
-                    href="{{ url('/dashboard') }}"
-                    class="rounded-md px-3 py-2 text-black ring-1 ring-transparent transition hover:text-black/70 focus:outline-none focus-visible:ring-[#FF2D20] dark:text-white dark:hover:text-white/80 dark:focus-visible:ring-white"
-                    >
-                    Dashboard
-                </a>
-            @else
-                <a
-                    href="{{ route('login') }}"
-                    class="rounded-md px-3 py-2 text-black ring-1 ring-transparent transition hover:text-black/70 focus:outline-none focus-visible:ring-[#FF2D20] dark:text-white dark:hover:text-white/80 dark:focus-visible:ring-white"
-                    >
-                    Log in
-                </a>
-
-                @if (Route::has('register'))
-                    <a
-                        href="{{ route('register') }}"
-                        class="rounded-md px-3 py-2 text-black ring-1 ring-transparent transition hover:text-black/70 focus:outline-none focus-visible:ring-[#FF2D20] dark:text-white dark:hover:text-white/80 dark:focus-visible:ring-white"
-                        >
-                        Register
-                    </a>
-                @endif
-            @endauth
-        </nav>
-    @endif
+<div class="py-10">
+    <h1>
+        Laravel + htmx example shop site
+    </h1>
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,3 +11,4 @@ Route::get('/items', [ItemController::class, 'index']);
 Route::get('/cart', [CartController::class, 'index']);
 Route::post('/cart', [CartController::class, 'update']);
 Route::delete('/cart', [CartController::class, 'destroy']);
+Route::get('/cart/sidemenu', [CartController::class, 'indexForSidemenu']);


### PR DESCRIPTION
- アイコン押下したらカートページに飛ぶように実装
- サイドメニューのカート情報とカートページを分けるため、ルートを追加
- アイコンは hroicons を使用
- サイドメニューでカートアイテム削除してから、md 以下にするとカートアイコンの個数が変化しないが、そんな使い方は想定できないので対応しない事にした。